### PR TITLE
Add '-r' rm file ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This utilities strips everything you do not need from an image and create a new 
 						-t target-image-name
 						[-p package]
 						[-f file]
+						[-r file]
 						[-x expose-port]
 						[-v]
 						[-u]
@@ -16,6 +17,7 @@ This utilities strips everything you do not need from an image and create a new 
 	-t target-image-name	the image name of the stripped image
 	-p package				package to include from image, multiple -p allowed.
 	-f file					file to include from image, multiple -f allowed.
+	-r file					file to remove from image, multiple -r allowed.
 	-x port					to expose.
 	-v						verbose.
 	-u                      compress executables and libs with upx (need to be installed)

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -6,7 +6,7 @@ set -e -o pipefail
 # strip-docker-image - strips the bare essentials from an image and exports them
 #
 # SYNOPSIS
-#	strip-docker-image -i image-name -t target-image-name -t [-p package | -f file] [-x expose-port] [-v] 
+#	strip-docker-image -i image-name -t target-image-name -t [-p package | -r file | -f file] [-x expose-port] [-v]
 #
 # OPTIONS
 #	-i image-name		to strip
@@ -59,7 +59,7 @@ set -e -o pipefail
 #
 
 function usage() {
-	echo "usage: $(basename $0) -i image-name -t stripped-image-name [-p package | -f file] [-v -u]" >&2
+	echo "usage: $(basename $0) -i image-name -t stripped-image-name [-p package | -r file | -f file] [-v -u]" >&2
 	echo " (for more see the readme)"
 	echo "	$@" >&2
 }

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -13,7 +13,7 @@ set -e -o pipefail
 #	-t target-image-name	the image name of the stripped image
 #	-p package		package to include from image, multiple -p allowed.
 #	-f file			file to include from image, multiple -f allowed.
-#	-r file			files to remove, useful when using -p package or globbing
+#	-r file			files to remove, useful when using -p package or -f globbing
 #	-x port			to expose.
 #	-v			verbose
 #

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -123,6 +123,7 @@ parse_commandline "$@"
 DIR=strip-docker-image-$$
 mkdir -p $DIR/export
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+#"
 
 docker run \
       --rm \

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -13,6 +13,7 @@ set -e -o pipefail
 #	-t target-image-name	the image name of the stripped image
 #	-p package		package to include from image, multiple -p allowed.
 #	-f file			file to include from image, multiple -f allowed.
+#	-r file			files to remove, useful when using -p package or globbing
 #	-x port			to expose.
 #	-v			verbose
 #
@@ -63,8 +64,13 @@ function usage() {
 	echo "	$@" >&2
 }
 
+#allows for >1 char separator + auto trim trailing space
+function join() {
+	local SEP="$1";	shift; echo $(printf -- "$SEP %s " "$@")
+}
+
 function parse_commandline() {
-	while getopts "vi:t:p:f:x:u" OPT; do
+	while getopts "vi:r:t:p:f:x:u" OPT; do
 	    case "$OPT" in
 		v)
 		    VERBOSE=-v
@@ -77,6 +83,9 @@ function parse_commandline() {
 		    ;;
 		i)
 		    IMAGE_NAME="$OPTARG"
+		    ;;
+		r)
+		    FILES_RM+=" $(printf "${OPTARG}")"
 		    ;;
 		t)
 		    TARGET_IMAGE_NAME="$OPTARG"
@@ -110,7 +119,7 @@ function parse_commandline() {
 		usage "Missing -p or -f options"
 		exit 1
 	fi
-	export PACKAGES FILES VERBOSE USE_UPX
+	export PACKAGES FILES FILES_RM VERBOSE USE_UPX
 }
 
 if [ $UID != 0 ] ; then
@@ -131,7 +140,7 @@ docker run \
 	  --volume $SCRIPT_DIR:/mybin \
 	  --entrypoint="/bin/bash" \
 	  $IMAGE_NAME \
-	  /mybin/strip-docker-image-export -d /export $VERBOSE $PACKAGES $(for f in ${FILES}; do echo -n " -f $f";done )
+	  /mybin/strip-docker-image-export -d /export $VERBOSE $PACKAGES $(join '-f' $FILES) $(join '-r' $FILES_RM)
 
 if [ -n "$USE_UPX" ]; then
 

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -66,6 +66,7 @@ function usage() {
 
 #allows for >1 char separator + auto trim trailing space
 function join() {
+	[[ -z "$2" ]] && return	# don't join if only SEP is passed
 	local SEP="$1";	shift; echo $(printf -- "$SEP %s " "$@")
 }
 

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -13,6 +13,7 @@ set -e
 #	-d export-directory	to copy content to, defaults to /export.
 #	-p package		package to include from image, multiple -p allowed.
 #	-f file			file to include from image, multiple -f allowed.
+#	-r file			files to remove, useful when using -p package or globbing
 #	-v			verbose
 #
 # DESCRIPTION
@@ -70,7 +71,7 @@ function usage() {
 
 function parse_commandline() {
 
-	while getopts "vp:f:d:" OPT; do
+	while getopts "vp:f:d:r:" OPT; do
 	    case "$OPT" in
 		v)
 		    VERBOSE=v
@@ -79,7 +80,10 @@ function parse_commandline() {
 		    PACKAGES+=" $OPTARG"
 		    ;;
 		f)
-		    FILES="$FILES $(printf "${OPTARG}")"
+		    FILES+=" $(printf "${OPTARG}")"
+		    ;;
+		r)
+		    FILES_RM+=" --exclude=$(printf "${OPTARG#/}")"
 		    ;;
 		d)
 		    EXPORT_DIR="$OPTARG"
@@ -179,4 +183,4 @@ tar czf - $(
 	| grep -v /usr/share/doc \
 	| grep -v /usr/share/man
 
-) | ( cd $EXPORT_DIR ; tar -xzh${VERBOSE}f - )
+) | ( cd $EXPORT_DIR ; tar ${FILES_RM} -xzh${VERBOSE}f - )

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -13,7 +13,7 @@ set -e
 #	-d export-directory	to copy content to, defaults to /export.
 #	-p package		package to include from image, multiple -p allowed.
 #	-f file			file to include from image, multiple -f allowed.
-#	-r file			files to remove, useful when using -p package or globbing
+#	-r file			files to remove, useful when using -p package or -f globbing
 #	-v			verbose
 #
 # DESCRIPTION

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -6,7 +6,7 @@ set -e
 #	strip-docker-image-export  - exports the bare essentials from a Docker image
 #
 # SYNOPSIS
-#	strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v]
+#	strip-docker-image-export  [-d export-dir ] [-p package | -r file | -f file] [-v]
 #
 #
 # OPTIONS
@@ -65,7 +65,7 @@ set -e
 export EXPORT_DIR=/export
 
 function usage() {
-	echo "usage: $(basename $0) [-v] [-d export-dir ] [-p package | -f file]" >&2
+	echo "usage: $(basename $0) [-v] [-d export-dir ] [-p package | -r file | -f file]" >&2
 	echo "  $@" >&2
 }
 


### PR DESCRIPTION
1. strip-docker-image: Fix bug where multiple '-f' were not appending to $FILES
1. Add -r' option to remove files from final image
1. misc mcedit syntax highlighting fix where it gets confused with multiple quotes in an $() construct

As an aside, can you turn on issues for your fork?  It seems that your fork is the best quality I've seen thus far as the official repo seems to have become neglected.

Also, if you need for me to squash these commits, just let me know.